### PR TITLE
Fixed if condition regarding validation of arnPrefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 		return
 	}
 
-	if *arnPrefix == "" || arnutil.ValidateARN(*arnPrefix) {
+	if *arnPrefix == "" || !arnutil.ValidateARN(*arnPrefix) {
 		log.Warn("ARN prefix not supplied or wrong, will try to detect")
 		detectedArnPrefix, err := arnutil.DetectARNPrefix(session)
 		if err != nil {


### PR DESCRIPTION
The if body should not be triggered when arnutil.ValidateARN(*arnPrefix) returned true.