### PR TITLE
Dockerfile cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .git
+Dockerfile
+bin
 vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@
 FROM golang:alpine as builder
 
 RUN set -ex && apk --update --no-cache add \
-    bash \
-    make \
     git \
-    cmake 
+    make
 
 WORKDIR /go/src/github.com/DataReply/alertmanager-sns-forwarder
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,14 @@ COPY . .
 RUN make all
 
 # final image
-FROM golang:alpine
+FROM scratch
 MAINTAINER o.grodzki@reply.de
 
-RUN apk add -U python && rm -rf /var/cache/apk/*
+# Add sh and other tools for debugging the container
+#COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+#COPY --from=builder /bin/ /bin/
 
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/DataReply/alertmanager-sns-forwarder/bin/linux/alertmanager-sns-forwarder /bin/alertmanager-sns-forwarder
 
 ENTRYPOINT ["/bin/alertmanager-sns-forwarder"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN make all
 
 # final image
 FROM scratch
-MAINTAINER o.grodzki@reply.de
+LABEL maintainer="o.grodzki@reply.de"
 
 # Add sh and other tools for debugging the container
 #COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1


### PR DESCRIPTION
This fixes #16 and replaces the deprecated MAINTAINER instruction with a maintainer LABEL.

The old docker image has a size of 412MB on my machine, the new one 23.6MB.