### PR TITLE
Use tag "latest" in order to have the templating working

### DIFF
--- a/deploy/stable.yaml
+++ b/deploy/stable.yaml
@@ -23,7 +23,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: alertmanager-sns-forwarder
-        image: alertmanager-sns-forwarder:0.1
+        image: alertmanager-sns-forwarder:latest
         imagePullPolicy: Always
         # You can also specify arguments
         # args: ["--addr=:9087", "--debug", "--arn-prefix=<some_prefix>"]


### PR DESCRIPTION
The deployment provided in deploy/stable.yaml is using the 0.1 tag. 
With this tag, we can't use a custom template file to change the message sent to SNS. 

In order to be able to, I had to use the "latest" tag, where the feature has been implemented I supect. 

I know that using the latest tag is not a best practice, but there is no other tag. 

This PR is to avoid other people to waste their times with this problem. 