### PR TITLE
bug/ intuitive listenaddress

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The app accepts some optional arguments, available as flags or env vars.
 
 Flag           | Env Variable           | Default       | Description
 ---------------|------------------------|---------------|------------
-`--addr`        | `SNS_FORWARDER_ADDRESS`     | `:9087`            | Address on which to listen.
+`--addr`        | `SNS_FORWARDER_ADDRESS`     | `9087`             | Address on which to listen.
 `--debug`       | `SNS_FORWARDER_DEBUG`       | `false`            | Debug mode
 `--arn-prefix`  | `SNS_FORWARDER_ARN_PREFIX`  | not specified      | Prefix to use for SNS topic ARNs. If not specified, will try to be detected automatically.
 `--sns-subject` | `SNS_SUBJECT`               | not specified      | Optional parameter to be used as the "Subject" line when the message is delivered to email endpoints.

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"bytes"
+    "fmt"
 	"encoding/json"
 	"html/template"
 	"io"
@@ -51,7 +52,7 @@ type Alert struct {
 var (
 	log = logrus.New()
 
-	listenAddr            = kingpin.Flag("addr", "Address on which to listen").Default(":9087").Envar("SNS_FORWARDER_ADDRESS").String()
+	listenAddr            = kingpin.Flag("addr", "Address on which to listen").Default("9087").Envar("SNS_FORWARDER_ADDRESS").String()
 	debug                 = kingpin.Flag("debug", "Debug mode").Default("false").Envar("SNS_FORWARDER_DEBUG").Bool()
 	arnPrefix             = kingpin.Flag("arn-prefix", "Prefix to use for ARNs").Envar("SNS_FORWARDER_ARN_PREFIX").String()
 	snsSubject            = kingpin.Flag("sns-subject", "SNS subject").Envar("SNS_SUBJECT").String()
@@ -165,9 +166,9 @@ func main() {
 
 	setupRouter(router)
 
-	log.Info("listening on", *listenAddr)
+    router.Run(fmt.Sprintf(":%s", *listenAddr))
 
-	router.Run(*listenAddr)
+	log.Info("listening on", *listenAddr)
 }
 
 func registerCustomPrometheusMetrics() {

--- a/main.go
+++ b/main.go
@@ -168,7 +168,7 @@ func main() {
 
     router.Run(fmt.Sprintf(":%s", *listenAddr))
 
-	log.Info("listening on", *listenAddr)
+	log.Info("listening on ", *listenAddr)
 }
 
 func registerCustomPrometheusMetrics() {


### PR DESCRIPTION
We tried to set this up yesterday and encountered an error where we was trying to set the port as `9087`. It took us a while to realize that is has to be `:9087`. This [SO question](https://stackoverflow.com/questions/54080917/prometheus-alertmanager-with-aws-sns) also has the same problem. This pull request lets the user set the listen address intuitively without the `:`. It is my first time writing Go, sorry if it is the wrong approach!